### PR TITLE
Improve responsiveness of member-row on About page.

### DIFF
--- a/components/styles/AboutStyles.js
+++ b/components/styles/AboutStyles.js
@@ -492,9 +492,9 @@ const TeamContainer = styled.div`
 		}
 	}
 
-	@media (max-width: ${size.mobileL}) and (min-width: 414px) {
+	@media (max-width: ${size.mobileL}) and (min-width: 420px) {
 		.member-row {
-			margin-top: -100px;
+			margin-top: 100px !important;
 		}
 	}
 


### PR DESCRIPTION
Fix spacing of Member Row on About page for devices between 500px and 425px wide.